### PR TITLE
Allow descendant class in STI to have its own state machine while using ...

### DIFF
--- a/lib/state_machine/audit_trail/transition_auditing.rb
+++ b/lib/state_machine/audit_trail/transition_auditing.rb
@@ -4,7 +4,7 @@
 
 module StateMachine::AuditTrail::TransitionAuditing
   attr_accessor :transition_class_name
-  
+
   # Public tells the state machine to hook in the appropriate before / after behaviour
   #
   # options: a Hash of options. keys that are used are :to => CustomTransitionClass,
@@ -35,6 +35,7 @@ module StateMachine::AuditTrail::TransitionAuditing
   end
 
   def default_transition_class_name
-    "#{owner_class.name}#{attribute.to_s.camelize}Transition"
+    owner_class_or_base_class = owner_class.respond_to?(:base_class) ? owner_class.base_class : owner_class
+    "#{owner_class_or_base_class.name}#{attribute.to_s.camelize}Transition"
   end
 end

--- a/spec/helpers/active_record.rb
+++ b/spec/helpers/active_record.rb
@@ -75,6 +75,16 @@ end
 class ActiveRecordTestModelDescendant < ActiveRecordTestModel
 end
 
+class ActiveRecordTestModelDescendantWithOwnStateMachine < ActiveRecordTestModel
+  state_machine :state, :initial => :new do
+    store_audit_trail
+
+    event :complete do
+      transition [:new] => :completed
+    end
+  end
+end
+
 class ActiveRecordTestModelWithMultipleStateMachines < ActiveRecord::Base
 
   state_machine :first, :initial => :beginning do

--- a/spec/state_machine/active_record_spec.rb
+++ b/spec/state_machine/active_record_spec.rb
@@ -103,4 +103,11 @@ describe StateMachine::AuditTrail::Backend::ActiveRecord do
       lambda { m.start! }.should_not raise_error
     end
   end
+
+  context 'on a class using STI with own state machine' do
+    it "should properly grab the class name from STI models" do
+      m = ActiveRecordTestModelDescendantWithOwnStateMachine.create!
+      lambda { m.complete! }.should_not raise_error
+    end
+  end
 end


### PR DESCRIPTION
...only one transition class for parent model

For example:

class Parent; end
class ParentStateTransition < ActiveRecord::Base
  belongs_to :parent
end

class ChildA
  state_machine :state, :initial => :new do
    store_audit_trail

```
event :complete do
  transition [:new] => :completed
end
```

  end
end

class ChildB
  state_machine :state, :initial => :waiting do
    store_audit_trail

```
event :start do
  transition [:waiting] => :finished
end
```

  end
end
