### PR TITLE
Make AuditTrail use an ActiveRecord association to expose and build audit events

### DIFF
--- a/lib/state_machine/audit_trail/backend.rb
+++ b/lib/state_machine/audit_trail/backend.rb
@@ -1,4 +1,4 @@
-class StateMachine::AuditTrail::Backend < Struct.new(:transition_class)
+class StateMachine::AuditTrail::Backend < Struct.new(:transition_class, :owner_class)
 
   autoload :Mongoid,      'state_machine/audit_trail/backend/mongoid'
   autoload :ActiveRecord, 'state_machine/audit_trail/backend/active_record'
@@ -13,14 +13,14 @@ class StateMachine::AuditTrail::Backend < Struct.new(:transition_class)
   #
   # in order to adda new ORM here, copy audit_trail/mongoid.rb to whatever you want to call the new file and implement the #log function there
   # then, return from here the appropriate object based on which ORM the transition_class is using  
-  def self.create_for_transition_class(transition_class, context_to_log = nil)
+  def self.create_for_transition_class(transition_class, owner_class, context_to_log = nil)
     if Object.const_defined?('ActiveRecord') && transition_class.ancestors.include?(::ActiveRecord::Base)
-      return StateMachine::AuditTrail::Backend::ActiveRecord.new(transition_class, context_to_log)
+      return StateMachine::AuditTrail::Backend::ActiveRecord.new(transition_class, owner_class, context_to_log)
     elsif Object.const_defined?('Mongoid') && transition_class.ancestors.include?(::Mongoid::Document)
       # Mongoid implementation doesn't yet support additional context fields
       raise NotImplemented, "Mongoid does not support additional context fields" if context_to_log.present?
 
-      return StateMachine::AuditTrail::Backend::Mongoid.new(transition_class)
+      return StateMachine::AuditTrail::Backend::Mongoid.new(transition_class, owner_class)
     else
       raise NotImplemented, "Only support for ActiveRecord and Mongoid is included at this time"
     end

--- a/lib/state_machine/audit_trail/backend/active_record.rb
+++ b/lib/state_machine/audit_trail/backend/active_record.rb
@@ -1,20 +1,18 @@
 class StateMachine::AuditTrail::Backend::ActiveRecord < StateMachine::AuditTrail::Backend
   attr_accessor :context_to_log
 
-  def initialize(transition_class, context_to_log = nil)
+  def initialize(transition_class, owner_class, context_to_log = nil)
     self.context_to_log = context_to_log
+    @association = transition_class.to_s.tableize.to_sym
     super transition_class
+    owner_class.has_many @association
   end
 
   def log(object, event, from, to, timestamp = Time.now)
     # Let ActiveRecord manage the timestamp for us so it does the 
     # right thing with regards to timezones.
-    params = {foreign_key_field(object) => object.id, :event => event, :from => from, :to => to}
+    params = {:event => event, :from => from, :to => to}
     params[self.context_to_log] = object.send(self.context_to_log) unless self.context_to_log.nil?
-    transition_class.create(params)
-  end
-
-  def foreign_key_field(object)
-    object.class.base_class.name.foreign_key.to_sym
+    object.send(@association).create(params)
   end
 end

--- a/lib/state_machine/audit_trail/transition_auditing.rb
+++ b/lib/state_machine/audit_trail/transition_auditing.rb
@@ -25,7 +25,7 @@ module StateMachine::AuditTrail::TransitionAuditing
 
   # Public returns an instance of the class which does the actual audit trail logging
   def audit_trail(context_to_log = nil)
-    @transition_auditor ||= StateMachine::AuditTrail::Backend.create_for_transition_class(transition_class, context_to_log)
+    @transition_auditor ||= StateMachine::AuditTrail::Backend.create_for_transition_class(transition_class, self.owner_class, context_to_log)
   end
 
   private

--- a/spec/state_machine/active_record_spec.rb
+++ b/spec/state_machine/active_record_spec.rb
@@ -4,8 +4,13 @@ require 'helpers/active_record'
 describe StateMachine::AuditTrail::Backend::ActiveRecord do
 
   it "should create an ActiveRecord backend" do
-    backend = StateMachine::AuditTrail::Backend.create_for_transition_class(ActiveRecordTestModelStateTransition)
+    backend = StateMachine::AuditTrail::Backend.create_for_transition_class(ActiveRecordTestModelStateTransition, ActiveRecordTestModel)
     backend.should be_instance_of(StateMachine::AuditTrail::Backend::ActiveRecord)
+  end
+
+  it "should create a has many association on the state machine owner" do
+    backend = StateMachine::AuditTrail::Backend.create_for_transition_class(ActiveRecordTestModelStateTransition, ActiveRecordTestModel)
+    ActiveRecordTestModel.reflect_on_association(:active_record_test_model_state_transitions).collection?.should be_true
   end
 
   context 'on an object with a single state machine' do
@@ -33,7 +38,7 @@ describe StateMachine::AuditTrail::Backend::ActiveRecord do
 
   context 'on an object with a single state machine that wants to log a single context' do
     before do
-      backend = StateMachine::AuditTrail::Backend.create_for_transition_class(ActiveRecordTestModelWithContextStateTransition, :context)
+      backend = StateMachine::AuditTrail::Backend.create_for_transition_class(ActiveRecordTestModelWithContextStateTransition, ActiveRecordTestModelWithContext, :context)
     end
 
     let!(:state_machine) { ActiveRecordTestModelWithContext.create! }


### PR DESCRIPTION
This uses ActiveRecord associations in the ActiveRecord backend to expose the events, so we can automatically do stuff like `order.order_financial_status_transitions` in Shopify, and also to create audit events in the code, which makes it a bit simpler. This is also good for me, because I can use `:inverse_of` on the `OrderFinancialStatusTransition`'s `belongs_to :order` association to save queries during checkout.

@wvanbergen look ok? 
