### PR TITLE
Update the ActiveRecord backend to not save entries for records that aren't yet saved

### DIFF
--- a/lib/state_machine/audit_trail/backend/active_record.rb
+++ b/lib/state_machine/audit_trail/backend/active_record.rb
@@ -13,6 +13,13 @@ class StateMachine::AuditTrail::Backend::ActiveRecord < StateMachine::AuditTrail
     # right thing with regards to timezones.
     params = {:event => event, :from => from, :to => to}
     params[self.context_to_log] = object.send(self.context_to_log) unless self.context_to_log.nil?
-    object.send(@association).create(params)
+
+    if object.new_record?
+      object.send(@association).build(params)
+    else
+      object.send(@association).create(params)
+    end
+
+    nil
   end
 end

--- a/lib/state_machine/audit_trail/transition_auditing.rb
+++ b/lib/state_machine/audit_trail/transition_auditing.rb
@@ -16,9 +16,11 @@ module StateMachine::AuditTrail::TransitionAuditing
       state_machine.audit_trail(options[:context_to_log]).log(object, transition.event, transition.from, transition.to)
     end
 
-    state_machine.owner_class.after_create do |object|
-      if !object.send(state_machine.attribute).nil?
-        state_machine.audit_trail(options[:context_to_log]).log(object, nil, nil, object.send(state_machine.attribute))
+    unless state_machine.action == nil
+      state_machine.owner_class.after_create do |object|
+        if !object.send(state_machine.attribute).nil?
+          state_machine.audit_trail(options[:context_to_log]).log(object, nil, nil, object.send(state_machine.attribute))
+        end
       end
     end
   end

--- a/spec/helpers/active_record.rb
+++ b/spec/helpers/active_record.rb
@@ -39,6 +39,10 @@ class ActiveRecordTestModelWithMultipleStateMachinesSecondTransition < ActiveRec
   belongs_to :test_model
 end
 
+class ActiveRecordTestModelWithMultipleStateMachinesThirdTransition < ActiveRecord::Base
+  belongs_to :test_model
+end
+
 class ActiveRecordTestModel < ActiveRecord::Base
 
   state_machine :state, :initial => :waiting do # log initial state?
@@ -102,6 +106,18 @@ class ActiveRecordTestModelWithMultipleStateMachines < ActiveRecord::Base
       transition nil => :beginning_second
     end
   end
+
+  state_machine :third, :action => nil do
+    store_audit_trail
+
+    event :begin_third do
+      transition nil => :beginning_third
+    end
+
+    event :end_third do
+      transition :beginning_third => :done_third
+    end
+  end
 end
 
 def create_transition_table(owner_class, state, add_context = false)
@@ -119,4 +135,5 @@ end
 create_transition_table(ActiveRecordTestModel, :state)
 create_transition_table(ActiveRecordTestModelWithContext, :state, true)
 create_transition_table(ActiveRecordTestModelWithMultipleStateMachines, :first)
-create_transition_table(ActiveRecordTestModelWithMultipleStateMachines, :second)  
+create_transition_table(ActiveRecordTestModelWithMultipleStateMachines, :second)
+create_transition_table(ActiveRecordTestModelWithMultipleStateMachines, :third)


### PR DESCRIPTION
If a state machine has `:action => nil` on it (like in Shopify), the saving of the record and the changing of its state are decoupled. This means that the state can be changed and state machine callbacks can be called on a new record without an ID yet, and its up to client code to save the record later.

That means its unsafe to try to create associated records until the record is saved. My code which calls `some_transition_trail_association.create` is doing this, so this PR changes it to do something smarter.

The state machine callbacks also get called when the record is saved even with action => nil, so I think this means we can just not create records if the record is new.

@wvanbergen you think thats ok?
