### PR TITLE
Actually test the namespaced transition model case.

### DIFF
--- a/spec/helpers/active_record.rb
+++ b/spec/helpers/active_record.rb
@@ -137,6 +137,12 @@ module SomeNamespace
   end
 end
 
+module SomeNamespace
+  class ActiveRecordTestModelStateTransition < ActiveRecord::Base
+    belongs_to :test_model
+  end
+end
+
 
 def create_transition_table(owner_class, state, add_context = false)
   class_name = "#{owner_class.name}#{state.to_s.camelize}Transition"

--- a/spec/state_machine/active_record_spec.rb
+++ b/spec/state_machine/active_record_spec.rb
@@ -18,6 +18,11 @@ describe StateMachine::AuditTrail::Backend::ActiveRecord do
     SomeNamespace::ActiveRecordTestModel.reflect_on_association(:active_record_test_model_state_transitions).collection?.should be_true
   end
 
+  it "should handle namespaced state transition model" do
+    backend = StateMachine::AuditTrail::Backend.create_for_transition_class(SomeNamespace::ActiveRecordTestModelStateTransition, ActiveRecordTestModel)
+    ActiveRecordTestModel.reflect_on_association(:active_record_test_model_state_transitions).collection?.should be_true
+  end
+
   shared_examples "a state machine audit trail" do
     it "should log an event with all fields set correctly" do
       state_machine.start!


### PR DESCRIPTION
I had a pull request accepted which fixed the issue around namespaced state transition models. However, the tests I added did not actually test that case (oops) and instead tested whether or not the base models could be namespaced. This change should add the missing coverage.
